### PR TITLE
Fix load order in openmw.cfg

### DIFF
--- a/app/openmw-base.cfg
+++ b/app/openmw-base.cfg
@@ -568,5 +568,5 @@ fallback=General_Werewolf_FOV,100
 encoding=win1252
 data="specify-me!"
 content=Morrowind.esm
-content=Bloodmoon.esm
 content=Tribunal.esm
+content=Bloodmoon.esm


### PR DESCRIPTION
Appearently tribunal.esm was loaded after bloodmoon.esm, which pretty much annoyed the heck out of me, even though tribunal should load before bloodmoon.