### PR TITLE
Update versionName to 0.46

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
     package="com.libopenmw.openmw"
     android:installLocation="auto"
     android:versionCode="1"
-    android:versionName="0.43">
+    android:versionName="0.46">
 
     <!-- Allow writing to external storage -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />


### PR DESCRIPTION
The string field above is displayed in settings, and naturally has caused confusion as to whether or not the openmw android build is on 0.43.0 or some newer version.